### PR TITLE
Add ridge probe baseline foundation

### DIFF
--- a/docs/ARTIFACTS.md
+++ b/docs/ARTIFACTS.md
@@ -396,6 +396,8 @@ Stores the raw predictions emitted by a run.
 - `program_name`
 - predicted score
 - for baseline outputs: `baseline_name`
+- for baseline artifacts: any required baseline-family metadata such as
+  `ridge_probe_selected_alpha_by_program`
 - recommended context: `cohort_id`, `split`
 - optional auxiliary outputs such as uncertainty or latent features
 
@@ -403,6 +405,10 @@ Stores the raw predictions emitted by a run.
 
 The evaluation layer should not have to rerun the model to inspect predictions.
 Predictions should be explicit artifacts.
+
+For the frozen baseline stack, one prediction artifact may contain multiple
+baseline families as long as row-level `baseline_name` stays explicit and any
+artifact-level baseline metadata is recorded alongside it.
 
 ---
 

--- a/docs/REPO_SETUP.md
+++ b/docs/REPO_SETUP.md
@@ -456,14 +456,21 @@ Each should:
 
 Current baseline note:
 
-- `run_baselines.py` currently covers the mean-baseline foundation
-  (`global_train_mean` and `mean_by_train_cohort`)
+- `run_baselines.py` currently covers the frozen deployable baseline stack
+  implemented so far:
+  - `global_train_mean`
+  - `mean_by_train_cohort`
 - it consumes an explicit score artifact plus manifest parquet
-- `--embeddings <path>` enables the frozen `knn_on_embeddings` baseline on the
-  same joined score rows; omit it to run mean baselines only
+- `--embeddings <path>` enables the frozen embedding-space baselines on the
+  same joined score rows:
+  - `knn_on_embeddings`
+  - `ridge_probe`
+- `ridge_probe` uses train-only standardization, tunes alpha on `val`, and
+  records `ridge_probe_selected_alpha_by_program` in the output artifact
+- omit `--embeddings` to run mean baselines only
 - the embeddings artifact must carry `observation_id`, `sample_id`, and
   finite embedding vectors at a single consistent dimensionality
-- embedding baselines and evaluation certificates are follow-up slices
+- evaluation certificates are the next follow-up slice
 
 ## 18. Logging policy
 

--- a/docs/plans/2026-03-21-baseline-ridge-probe-design.md
+++ b/docs/plans/2026-03-21-baseline-ridge-probe-design.md
@@ -1,0 +1,108 @@
+# Baseline Ridge Probe Design
+
+## Summary
+
+This slice adds the last required deployable baseline in the frozen v1 stack:
+`ridge_probe`.
+
+The goal is to keep the baseline runner contract-first and boring:
+
+- standardized embedding features, using train-only statistics
+- per-program ridge regression
+- alpha grid fixed to `{0.1, 1.0, 10.0}`
+- fit on `train`
+- tune on `val`
+- predict on all splits without external-test peeking
+
+This PR does not emit evaluation certificates yet.
+
+## Goals
+
+- Implement `ridge_probe` as a frozen embedding-space deployable baseline.
+- Record the chosen alpha in the baseline prediction artifact at artifact level.
+- Fail loudly when the split structure is insufficient for honest tuning.
+- Reuse the existing score + manifest + embedding join path from the KNN slice.
+- Keep long-form prediction rows unchanged.
+
+## Non-Goals
+
+- No evaluation certificate generation.
+- No alpha search beyond `{0.1, 1.0, 10.0}`.
+- No multi-target shared model fitting.
+- No oracle variants or external-test-informed tuning.
+
+## Architecture
+
+### Package shape
+
+- `src/spatial_ci/baselines/ridge.py`
+  - frozen per-program ridge fitting and prediction
+- `src/spatial_ci/baselines/artifacts.py`
+  - artifact-level `ridge_probe_selected_alpha_by_program`
+- `src/spatial_ci/baselines/runner.py`
+  - extend baseline execution to include ridge when embeddings are present
+- `scripts/run_baselines.py`
+  - no new flag required; embeddings still gate embedding-aware baselines
+
+### Data flow
+
+1. load score artifact and keep only `ScoreStatus.OK` rows
+2. join manifest on `sample_id`
+3. if embeddings are present, join them on `observation_id`
+4. emit mean baselines
+5. emit `knn_on_embeddings`
+6. emit `ridge_probe`
+7. write one combined long-form baseline prediction artifact
+
+### Ridge semantics
+
+For each `program_name`:
+
+- take rows with `split == train` as the fit pool
+- take rows with `split == val` as the tuning pool
+- standardize embedding dimensions using train-only mean and scale
+- fit one ridge model per alpha in `{0.1, 1.0, 10.0}`
+- choose the alpha with lowest validation MSE
+- break ties by smaller alpha for determinism
+- refit is not needed because all candidate models are already fit on full train
+- predict for every available row using the chosen alpha
+
+Artifact-level metadata:
+
+- `ridge_probe_selected_alpha_by_program: dict[str, float] | None`
+
+Rules:
+
+- if any `ridge_probe` rows are present, the mapping must exist and cover every
+  predicted ridge program exactly
+- if no `ridge_probe` rows are present, the mapping must be `None`
+
+## Failure Behavior
+
+Hard failures in this slice:
+
+- embeddings missing for an eligible score row
+- a program has fewer than 2 train rows
+- a program has no val rows
+- non-finite or inconsistent embedding features
+- artifact metadata and ridge rows disagree on selected alphas
+
+## Testing Strategy
+
+Required tests:
+
+- ridge predictor chooses the correct alpha on deterministic fixtures
+- standardization uses train-only statistics
+- ridge fails when a program has fewer than 2 train rows
+- ridge fails when a program has no val rows
+- artifact roundtrip preserves `ridge_probe_selected_alpha_by_program`
+- runner emits mean + KNN + ridge when embeddings are present
+- runner records alpha metadata when ridge rows are present
+- CLI path with embeddings emits ridge predictions and alpha metadata
+
+## Follow-Up Slice
+
+After this PR:
+
+1. emit evaluation certificates
+2. run the full baseline-only benchmark end-to-end

--- a/docs/plans/2026-03-21-baseline-ridge-probe.md
+++ b/docs/plans/2026-03-21-baseline-ridge-probe.md
@@ -1,0 +1,182 @@
+# Baseline Ridge Probe Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add the frozen `ridge_probe` deployable baseline on top of the existing score + manifest + embedding baseline runner, and record the selected alpha per program in the baseline prediction artifact.
+
+**Architecture:** Implement per-program ridge regression in `spatial_ci.baselines.ridge`, extend baseline prediction artifacts with artifact-level `ridge_probe_selected_alpha_by_program`, and extend the runner/CLI so embedding-aware runs emit mean baselines, KNN, and ridge together under frozen tuning rules.
+
+**Tech Stack:** Python 3.13, Pydantic v2, Polars, NumPy, pytest, Click
+
+---
+
+### Task 1: Extend baseline prediction artifacts for ridge metadata
+
+**Files:**
+- Modify: `src/spatial_ci/baselines/artifacts.py`
+- Test: `tests/baselines/test_baseline_artifacts.py`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- artifact roundtrip with `ridge_probe_selected_alpha_by_program`
+- artifact rejects ridge rows without matching alpha metadata
+- artifact rejects alpha metadata when no ridge rows are present
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/baselines/test_baseline_artifacts.py -q`
+Expected: FAIL because the artifact does not yet model ridge alpha provenance.
+
+**Step 3: Write minimal implementation**
+
+Extend `BaselinePredictionArtifact` with:
+- `ridge_probe_selected_alpha_by_program: dict[str, float] | None = None`
+
+Add validation so:
+- ridge rows require non-null metadata covering every ridge program
+- non-ridge artifacts keep the field as `None`
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/baselines/test_baseline_artifacts.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/spatial_ci/baselines/artifacts.py tests/baselines/test_baseline_artifacts.py
+git commit -m "feat: add ridge alpha metadata to baseline artifacts"
+```
+
+### Task 2: Add frozen ridge prediction logic
+
+**Files:**
+- Create: `src/spatial_ci/baselines/ridge.py`
+- Test: `tests/baselines/test_ridge.py`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- alpha selection from `{0.1, 1.0, 10.0}`
+- train-only standardization
+- failure when a program has fewer than 2 train rows
+- failure when a program has no val rows
+- deterministic tie-breaking toward smaller alpha
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/baselines/test_ridge.py -q`
+Expected: FAIL because `ridge.py` does not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Implement:
+- `predict_ridge_probe(frame: pl.DataFrame, *, alphas: tuple[float, ...] = (0.1, 1.0, 10.0)) -> tuple[pl.DataFrame, dict[str, float]]`
+
+Requirements:
+- require `observation_id`, `sample_id`, `cohort_id`, `split`, `program_name`,
+  `raw_rank_evidence`, and `embedding`
+- fit candidates on `train`
+- select alpha by validation MSE on `val`
+- predict long-form rows with `baseline_name = "ridge_probe"`
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/baselines/test_ridge.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/spatial_ci/baselines/ridge.py tests/baselines/test_ridge.py
+git commit -m "feat: add frozen ridge baseline"
+```
+
+### Task 3: Extend baseline runner for ridge
+
+**Files:**
+- Modify: `src/spatial_ci/baselines/runner.py`
+- Modify: `src/spatial_ci/baselines/__init__.py`
+- Test: `tests/baselines/test_runner.py`
+
+**Step 1: Write the failing tests**
+
+Add tests for:
+- successful combined output with mean baselines, KNN, and ridge when embeddings are provided
+- alpha metadata is populated for ridge runs
+- failure when a required program has no val rows
+- failure when a required program has too few train rows
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/baselines/test_runner.py -q`
+Expected: FAIL because the runner does not emit ridge or record alpha metadata.
+
+**Step 3: Write minimal implementation**
+
+Extend the runner to:
+- call `predict_ridge_probe()` whenever embeddings are present
+- merge its predictions with the existing prediction frames
+- store `ridge_probe_selected_alpha_by_program` on the artifact
+- preserve the existing mean-only behavior when embeddings are absent
+
+**Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/baselines/test_runner.py -q`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add src/spatial_ci/baselines/runner.py src/spatial_ci/baselines/__init__.py tests/baselines/test_runner.py
+git commit -m "feat: add ridge baseline runner integration"
+```
+
+### Task 4: Extend the CLI and docs
+
+**Files:**
+- Modify: `scripts/run_baselines.py`
+- Modify: `docs/ARTIFACTS.md`
+- Modify: `docs/REPO_SETUP.md`
+- Test: `tests/baselines/test_run_baselines_cli.py`
+- Modify: `LOCAL_TODO.md` (local-only, do not commit)
+
+**Step 1: Write the failing tests**
+
+Add CLI coverage for:
+- embeddings path now emitting mean + KNN + ridge
+- ridge alpha metadata present in the written artifact
+
+**Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/baselines/test_run_baselines_cli.py -q`
+Expected: FAIL because the CLI output contract does not yet include ridge metadata.
+
+**Step 3: Write minimal implementation**
+
+Keep the current `--embeddings` flag and update CLI messaging/docs to reflect
+all embedding-aware baselines.
+
+**Step 4: Run targeted verification**
+
+Run:
+- `uv run pytest tests/baselines/test_baseline_artifacts.py tests/baselines/test_ridge.py tests/baselines/test_runner.py tests/baselines/test_run_baselines_cli.py -q`
+- `uv run ruff check src/spatial_ci/baselines tests/baselines scripts/run_baselines.py`
+- `uv run mypy src/spatial_ci/baselines tests/baselines scripts/run_baselines.py`
+
+Expected: PASS
+
+**Step 5: Run broader verification**
+
+Run:
+- `uv run pytest -q`
+
+Expected: PASS
+
+**Step 6: Commit**
+
+```bash
+git add scripts/run_baselines.py docs/ARTIFACTS.md docs/REPO_SETUP.md tests/baselines/test_run_baselines_cli.py
+git commit -m "docs: record ridge baseline foundation"
+```

--- a/scripts/run_baselines.py
+++ b/scripts/run_baselines.py
@@ -40,7 +40,10 @@ from spatial_ci.baselines.runner import run_mean_baselines
     "--embeddings",
     type=Path,
     required=False,
-    help="Optional path to embedding artifact",
+    help=(
+        "Optional path to embedding artifact; enables knn_on_embeddings and "
+        "ridge_probe"
+    ),
 )
 def main(
     scores: Path,
@@ -52,7 +55,7 @@ def main(
     manifest_id: str | None,
     embeddings: Path | None,
 ) -> None:
-    """Run the mean-baseline foundation against frozen score and manifest inputs."""
+    """Run the frozen deployable baseline stack against score and manifest inputs."""
 
     artifact = run_mean_baselines(
         score_artifact_path=scores,

--- a/src/spatial_ci/baselines/__init__.py
+++ b/src/spatial_ci/baselines/__init__.py
@@ -8,6 +8,7 @@ from spatial_ci.baselines.artifacts import (
     write_baseline_prediction_artifact,
 )
 from spatial_ci.baselines.knn import predict_knn_on_embeddings
+from spatial_ci.baselines.ridge import predict_ridge_probe
 from spatial_ci.baselines.runner import run_mean_baselines
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "BaselinePredictionRow",
     "read_baseline_prediction_artifact",
     "predict_knn_on_embeddings",
+    "predict_ridge_probe",
     "run_mean_baselines",
     "write_baseline_prediction_artifact",
 ]

--- a/src/spatial_ci/baselines/artifacts.py
+++ b/src/spatial_ci/baselines/artifacts.py
@@ -2,6 +2,7 @@
 
 import json
 from enum import Enum
+from math import isfinite
 from pathlib import Path
 
 import pyarrow as pa
@@ -47,6 +48,7 @@ class BaselinePredictionArtifact(BaseModel):
     source_score_artifact_hash: str = Field(min_length=1)
     source_manifest_path: str = Field(min_length=1)
     source_manifest_hash: str = Field(min_length=1)
+    ridge_probe_selected_alpha_by_program: dict[str, float] | None = None
     n_rows: int = Field(ge=0)
     rows: tuple[BaselinePredictionRow, ...]
 
@@ -54,6 +56,41 @@ class BaselinePredictionArtifact(BaseModel):
     def validate_row_count(self) -> "BaselinePredictionArtifact":
         if self.n_rows != len(self.rows):
             raise ValueError("n_rows must match len(rows)")
+        ridge_programs = {
+            row.program_name
+            for row in self.rows
+            if row.baseline_name is BaselineName.RIDGE_PROBE
+        }
+        if not ridge_programs:
+            if self.ridge_probe_selected_alpha_by_program is not None:
+                raise ValueError(
+                    "ridge_probe_selected_alpha_by_program must be None when no "
+                    "ridge_probe rows are present"
+                )
+            return self
+
+        selected_alpha_by_program = self.ridge_probe_selected_alpha_by_program
+        if selected_alpha_by_program is None:
+            raise ValueError(
+                "ridge_probe_selected_alpha_by_program is required when ridge_probe "
+                "rows are present"
+            )
+        if set(selected_alpha_by_program) != ridge_programs:
+            raise ValueError(
+                "ridge_probe_selected_alpha_by_program must match the predicted "
+                "ridge_probe program set"
+            )
+        invalid_programs = sorted(
+            program_name
+            for program_name, alpha in selected_alpha_by_program.items()
+            if not isfinite(alpha) or alpha <= 0.0
+        )
+        if invalid_programs:
+            invalid_display = ", ".join(invalid_programs)
+            raise ValueError(
+                "ridge_probe_selected_alpha_by_program must contain positive finite "
+                f"alpha values; invalid programs: {invalid_display}"
+            )
         return self
 
 

--- a/src/spatial_ci/baselines/ridge.py
+++ b/src/spatial_ci/baselines/ridge.py
@@ -6,6 +6,7 @@ from math import isfinite
 from typing import TypedDict, cast
 
 import numpy as np
+import numpy.typing as npt
 import polars as pl
 
 from spatial_ci.baselines.artifacts import BaselineName
@@ -21,6 +22,7 @@ REQUIRED_COLUMNS = {
 }
 
 DEFAULT_ALPHAS = (0.1, 1.0, 10.0)
+FloatArray = npt.NDArray[np.float64]
 
 
 class _RidgeRow(TypedDict):
@@ -49,7 +51,7 @@ def _validated_alphas(alphas: tuple[float, ...]) -> tuple[float, ...]:
     return tuple(sorted(alphas))
 
 
-def _embedding_matrix(rows: list[_RidgeRow], *, program_name: str) -> np.ndarray:
+def _embedding_matrix(rows: list[_RidgeRow], *, program_name: str) -> FloatArray:
     embeddings = np.asarray([row["embedding"] for row in rows], dtype=float)
     if embeddings.ndim != 2:
         raise ValueError(f"program {program_name} has malformed embedding rows")
@@ -57,39 +59,46 @@ def _embedding_matrix(rows: list[_RidgeRow], *, program_name: str) -> np.ndarray
         raise ValueError(f"program {program_name} has empty embedding vectors")
     if not np.isfinite(embeddings).all():
         raise ValueError(f"program {program_name} has non-finite embedding values")
-    return embeddings
+    return cast("FloatArray", embeddings)
 
 
-def _response_vector(rows: list[_RidgeRow]) -> np.ndarray:
-    return np.asarray([row["raw_rank_evidence"] for row in rows], dtype=float)
+def _response_vector(rows: list[_RidgeRow]) -> FloatArray:
+    return cast(
+        "FloatArray",
+        np.asarray([row["raw_rank_evidence"] for row in rows], dtype=float),
+    )
 
 
 def _standardize(
-    train_matrix: np.ndarray, matrix: np.ndarray
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    train_matrix: FloatArray, matrix: FloatArray
+) -> tuple[FloatArray, FloatArray, FloatArray]:
     means = train_matrix.mean(axis=0)
     scales = train_matrix.std(axis=0)
     scales[scales == 0.0] = 1.0
-    return (train_matrix - means) / scales, (matrix - means) / scales, means
+    return (
+        cast("FloatArray", (train_matrix - means) / scales),
+        cast("FloatArray", (matrix - means) / scales),
+        cast("FloatArray", means),
+    )
 
 
 def _ridge_coefficients(
-    standardized_train: np.ndarray, responses: np.ndarray, *, alpha: float
-) -> np.ndarray:
+    standardized_train: FloatArray, responses: FloatArray, *, alpha: float
+) -> FloatArray:
     design = np.column_stack([np.ones(standardized_train.shape[0]), standardized_train])
     penalty = np.eye(design.shape[1], dtype=float)
     penalty[0, 0] = 0.0
     system = design.T @ design + (alpha * penalty)
     rhs = design.T @ responses
     try:
-        return np.linalg.solve(system, rhs)
+        return cast("FloatArray", np.linalg.solve(system, rhs))
     except np.linalg.LinAlgError:
-        return np.linalg.pinv(system) @ rhs
+        return cast("FloatArray", np.linalg.pinv(system) @ rhs)
 
 
-def _ridge_predict(standardized: np.ndarray, coefficients: np.ndarray) -> np.ndarray:
+def _ridge_predict(standardized: FloatArray, coefficients: FloatArray) -> FloatArray:
     design = np.column_stack([np.ones(standardized.shape[0]), standardized])
-    return design @ coefficients
+    return cast("FloatArray", design @ coefficients)
 
 
 def _program_predictions(

--- a/src/spatial_ci/baselines/ridge.py
+++ b/src/spatial_ci/baselines/ridge.py
@@ -1,0 +1,185 @@
+"""Frozen ridge baseline predictions on embedding vectors."""
+
+from __future__ import annotations
+
+from math import isfinite
+from typing import TypedDict, cast
+
+import numpy as np
+import polars as pl
+
+from spatial_ci.baselines.artifacts import BaselineName
+
+REQUIRED_COLUMNS = {
+    "observation_id",
+    "sample_id",
+    "cohort_id",
+    "split",
+    "program_name",
+    "raw_rank_evidence",
+    "embedding",
+}
+
+DEFAULT_ALPHAS = (0.1, 1.0, 10.0)
+
+
+class _RidgeRow(TypedDict):
+    observation_id: str
+    sample_id: str
+    cohort_id: str
+    split: str
+    program_name: str
+    raw_rank_evidence: float
+    embedding: list[float]
+
+
+def _validate_required_columns(frame: pl.DataFrame) -> None:
+    missing = sorted(REQUIRED_COLUMNS - set(frame.columns))
+    if missing:
+        missing_display = ", ".join(missing)
+        raise ValueError(f"baseline input frame is missing columns: {missing_display}")
+
+
+def _validated_alphas(alphas: tuple[float, ...]) -> tuple[float, ...]:
+    if not alphas:
+        raise ValueError("alphas must not be empty")
+    invalid = [alpha for alpha in alphas if not isfinite(alpha) or alpha <= 0.0]
+    if invalid:
+        raise ValueError("alphas must be positive finite values")
+    return tuple(sorted(alphas))
+
+
+def _embedding_matrix(rows: list[_RidgeRow], *, program_name: str) -> np.ndarray:
+    embeddings = np.asarray([row["embedding"] for row in rows], dtype=float)
+    if embeddings.ndim != 2:
+        raise ValueError(f"program {program_name} has malformed embedding rows")
+    if embeddings.shape[1] == 0:
+        raise ValueError(f"program {program_name} has empty embedding vectors")
+    if not np.isfinite(embeddings).all():
+        raise ValueError(f"program {program_name} has non-finite embedding values")
+    return embeddings
+
+
+def _response_vector(rows: list[_RidgeRow]) -> np.ndarray:
+    return np.asarray([row["raw_rank_evidence"] for row in rows], dtype=float)
+
+
+def _standardize(
+    train_matrix: np.ndarray, matrix: np.ndarray
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    means = train_matrix.mean(axis=0)
+    scales = train_matrix.std(axis=0)
+    scales[scales == 0.0] = 1.0
+    return (train_matrix - means) / scales, (matrix - means) / scales, means
+
+
+def _ridge_coefficients(
+    standardized_train: np.ndarray, responses: np.ndarray, *, alpha: float
+) -> np.ndarray:
+    design = np.column_stack([np.ones(standardized_train.shape[0]), standardized_train])
+    penalty = np.eye(design.shape[1], dtype=float)
+    penalty[0, 0] = 0.0
+    system = design.T @ design + (alpha * penalty)
+    rhs = design.T @ responses
+    try:
+        return np.linalg.solve(system, rhs)
+    except np.linalg.LinAlgError:
+        return np.linalg.pinv(system) @ rhs
+
+
+def _ridge_predict(standardized: np.ndarray, coefficients: np.ndarray) -> np.ndarray:
+    design = np.column_stack([np.ones(standardized.shape[0]), standardized])
+    return design @ coefficients
+
+
+def _program_predictions(
+    program_frame: pl.DataFrame, *, alphas: tuple[float, ...]
+) -> tuple[list[dict[str, object]], float]:
+    program_rows = cast("list[_RidgeRow]", program_frame.to_dicts())
+    if not program_rows:
+        raise ValueError("program frame must not be empty")
+    program_name = program_rows[0]["program_name"]
+
+    train_rows = [row for row in program_rows if row["split"] == "train"]
+    val_rows = [row for row in program_rows if row["split"] == "val"]
+    if len(train_rows) < 2:
+        raise ValueError(f"program {program_name} has fewer than 2 train rows")
+    if not val_rows:
+        raise ValueError(f"program {program_name} has no val rows")
+
+    train_matrix = _embedding_matrix(train_rows, program_name=program_name)
+    all_matrix = _embedding_matrix(program_rows, program_name=program_name)
+    standardized_train, standardized_all, _ = _standardize(train_matrix, all_matrix)
+    train_response = _response_vector(train_rows)
+
+    val_index_by_observation_id = {
+        row["observation_id"]: index for index, row in enumerate(program_rows)
+    }
+    val_indices = [
+        val_index_by_observation_id[row["observation_id"]] for row in val_rows
+    ]
+    standardized_val = standardized_all[val_indices]
+    val_response = _response_vector(val_rows)
+
+    best_alpha: float | None = None
+    best_score: float | None = None
+    best_coefficients: np.ndarray | None = None
+    for alpha in alphas:
+        coefficients = _ridge_coefficients(
+            standardized_train,
+            train_response,
+            alpha=alpha,
+        )
+        val_predictions = _ridge_predict(standardized_val, coefficients)
+        mse = float(np.mean(np.square(val_predictions - val_response)))
+        if best_score is None or mse < best_score or (
+            np.isclose(mse, best_score)
+            and best_alpha is not None
+            and alpha < best_alpha
+        ):
+            best_alpha = alpha
+            best_score = mse
+            best_coefficients = coefficients
+
+    if best_alpha is None or best_coefficients is None:
+        raise ValueError(f"program {program_name} did not produce a valid ridge fit")
+
+    all_predictions = _ridge_predict(standardized_all, best_coefficients)
+    predictions = [
+        {
+            "observation_id": row["observation_id"],
+            "sample_id": row["sample_id"],
+            "cohort_id": row["cohort_id"],
+            "split": row["split"],
+            "program_name": program_name,
+            "baseline_name": BaselineName.RIDGE_PROBE.value,
+            "predicted_score": float(predicted_score),
+        }
+        for row, predicted_score in zip(program_rows, all_predictions, strict=True)
+    ]
+    return predictions, best_alpha
+
+
+def predict_ridge_probe(
+    frame: pl.DataFrame, *, alphas: tuple[float, ...] = DEFAULT_ALPHAS
+) -> tuple[pl.DataFrame, dict[str, float]]:
+    """Predict raw rank evidence with frozen ridge semantics."""
+
+    _validate_required_columns(frame)
+    validated_alphas = _validated_alphas(alphas)
+
+    predictions: list[dict[str, object]] = []
+    selected_alpha_by_program: dict[str, float] = {}
+    for program_name in sorted(frame.get_column("program_name").unique()):
+        program_frame = frame.filter(pl.col("program_name") == program_name)
+        program_predictions, best_alpha = _program_predictions(
+            program_frame,
+            alphas=validated_alphas,
+        )
+        predictions.extend(program_predictions)
+        selected_alpha_by_program[str(program_name)] = best_alpha
+
+    return pl.DataFrame(predictions), selected_alpha_by_program
+
+
+__all__ = ["predict_ridge_probe"]

--- a/src/spatial_ci/baselines/runner.py
+++ b/src/spatial_ci/baselines/runner.py
@@ -15,6 +15,7 @@ from spatial_ci.baselines.mean import (
     predict_global_train_mean,
     predict_mean_by_train_cohort,
 )
+from spatial_ci.baselines.ridge import predict_ridge_probe
 from spatial_ci.embeddings.artifacts import read_embedding_artifact
 from spatial_ci.scoring.artifacts import read_score_artifact
 
@@ -169,11 +170,16 @@ def run_mean_baselines(
         predict_global_train_mean(joined),
         predict_mean_by_train_cohort(joined),
     ]
+    ridge_probe_selected_alpha_by_program: dict[str, float] | None = None
     if embedding_artifact_path is not None:
         joined_with_embeddings = _joined_embedding_frame(
             joined,
             _embedding_frame(embedding_artifact_path),
         )
+        ridge_predictions, ridge_probe_selected_alpha_by_program = (
+            predict_ridge_probe(joined_with_embeddings)
+        )
+        prediction_frames.append(ridge_predictions)
         prediction_frames.append(predict_knn_on_embeddings(joined_with_embeddings))
     prediction_frame = pl.concat(prediction_frames, how="vertical")
     rows = _prediction_rows(prediction_frame)
@@ -188,6 +194,7 @@ def run_mean_baselines(
         source_score_artifact_hash=_hash_file(score_artifact_path),
         source_manifest_path=str(manifest_path),
         source_manifest_hash=_hash_file(manifest_path),
+        ridge_probe_selected_alpha_by_program=ridge_probe_selected_alpha_by_program,
         n_rows=len(rows),
         rows=rows,
     )

--- a/tests/baselines/test_baseline_artifacts.py
+++ b/tests/baselines/test_baseline_artifacts.py
@@ -113,3 +113,99 @@ def test_baseline_prediction_artifact_roundtrips_through_parquet(
     observed = read_baseline_prediction_artifact(path)
 
     assert observed == artifact
+
+
+def test_baseline_prediction_artifact_roundtrips_ridge_alpha_metadata(
+    tmp_path: Path,
+) -> None:
+    artifact = BaselinePredictionArtifact(
+        run_id="baseline-run-1",
+        baseline_contract_id="standard_baselines_v1",
+        split_contract_id="breast_visium_split_v1",
+        target_definition_id="breast_visium_hallmarks_v1",
+        scoring_contract_id="singscore_r_v1",
+        manifest_id="breast_manifest_v1",
+        source_score_artifact_path="scores.parquet",
+        source_score_artifact_hash="a" * 64,
+        source_manifest_path="manifest.parquet",
+        source_manifest_hash="b" * 64,
+        ridge_probe_selected_alpha_by_program={"HALLMARK_HYPOXIA": 0.1},
+        n_rows=1,
+        rows=(
+            BaselinePredictionRow(
+                observation_id="obs-1",
+                sample_id="sample-1",
+                cohort_id="cohort-a",
+                split="val",
+                program_name="HALLMARK_HYPOXIA",
+                baseline_name=BaselineName.RIDGE_PROBE,
+                predicted_score=0.42,
+            ),
+        ),
+    )
+    path = tmp_path / "baseline_predictions.parquet"
+
+    write_baseline_prediction_artifact(artifact, path)
+    observed = read_baseline_prediction_artifact(path)
+
+    assert observed == artifact
+
+
+def test_baseline_prediction_artifact_rejects_ridge_rows_without_alpha_metadata(
+) -> None:
+    with pytest.raises(ValidationError, match="ridge_probe_selected_alpha_by_program"):
+        BaselinePredictionArtifact(
+            run_id="baseline-run-1",
+            baseline_contract_id="standard_baselines_v1",
+            split_contract_id="breast_visium_split_v1",
+            target_definition_id="breast_visium_hallmarks_v1",
+            scoring_contract_id="singscore_r_v1",
+            manifest_id="breast_manifest_v1",
+            source_score_artifact_path="scores.parquet",
+            source_score_artifact_hash="a" * 64,
+            source_manifest_path="manifest.parquet",
+            source_manifest_hash="b" * 64,
+            ridge_probe_selected_alpha_by_program=None,
+            n_rows=1,
+            rows=(
+                BaselinePredictionRow(
+                    observation_id="obs-1",
+                    sample_id="sample-1",
+                    cohort_id="cohort-a",
+                    split="val",
+                    program_name="HALLMARK_HYPOXIA",
+                    baseline_name=BaselineName.RIDGE_PROBE,
+                    predicted_score=0.42,
+                ),
+            ),
+        )
+
+
+def test_baseline_prediction_artifact_rejects_non_ridge_rows_with_alpha_metadata(
+) -> None:
+    with pytest.raises(ValidationError, match="ridge_probe_selected_alpha_by_program"):
+        BaselinePredictionArtifact(
+            run_id="baseline-run-1",
+            baseline_contract_id="standard_baselines_v1",
+            split_contract_id="breast_visium_split_v1",
+            target_definition_id="breast_visium_hallmarks_v1",
+            scoring_contract_id="singscore_r_v1",
+            manifest_id="breast_manifest_v1",
+            source_score_artifact_path="scores.parquet",
+            source_score_artifact_hash="a" * 64,
+            source_manifest_path="manifest.parquet",
+            source_manifest_hash="b" * 64,
+            ridge_probe_selected_alpha_by_program={"HALLMARK_HYPOXIA": 0.1},
+            n_rows=1,
+            rows=(
+                BaselinePredictionRow(
+                    observation_id="obs-1",
+                    sample_id="sample-1",
+                    cohort_id="cohort-a",
+                    split="val",
+                    program_name="HALLMARK_HYPOXIA",
+                    baseline_name=BaselineName.GLOBAL_TRAIN_MEAN,
+                    predicted_score=0.42,
+                ),
+            ),
+        )

--- a/tests/baselines/test_ridge.py
+++ b/tests/baselines/test_ridge.py
@@ -1,0 +1,202 @@
+import polars as pl
+import pytest
+
+from spatial_ci.baselines.artifacts import BaselineName
+from spatial_ci.baselines.ridge import predict_ridge_probe
+
+
+def _ridge_input_frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        [
+            {
+                "observation_id": "train-1",
+                "sample_id": "s1",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.0,
+                "embedding": [0.0],
+            },
+            {
+                "observation_id": "train-2",
+                "sample_id": "s2",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 1.0,
+                "embedding": [1.0],
+            },
+            {
+                "observation_id": "val-1",
+                "sample_id": "s3",
+                "cohort_id": "cohort-a",
+                "split": "val",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.2,
+                "embedding": [0.2],
+            },
+            {
+                "observation_id": "val-2",
+                "sample_id": "s4",
+                "cohort_id": "cohort-a",
+                "split": "val",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.8,
+                "embedding": [0.8],
+            },
+            {
+                "observation_id": "test-1",
+                "sample_id": "s5",
+                "cohort_id": "external-b",
+                "split": "test_external",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.5,
+                "embedding": [0.5],
+            },
+        ]
+    )
+
+
+def test_predict_ridge_probe_selects_alpha_from_frozen_grid() -> None:
+    predictions, selected_alpha_by_program = predict_ridge_probe(_ridge_input_frame())
+
+    assert selected_alpha_by_program == {"PROGRAM_A": 0.1}
+    assert set(predictions.get_column("baseline_name")) == {
+        BaselineName.RIDGE_PROBE.value
+    }
+    assert predictions.height == 5
+
+
+def test_predict_ridge_probe_uses_train_only_standardization() -> None:
+    frame = pl.DataFrame(
+        [
+            {
+                "observation_id": "train-1",
+                "sample_id": "s1",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.0,
+                "embedding": [0.0],
+            },
+            {
+                "observation_id": "train-2",
+                "sample_id": "s2",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 1.0,
+                "embedding": [1.0],
+            },
+            {
+                "observation_id": "val-1",
+                "sample_id": "s3",
+                "cohort_id": "cohort-a",
+                "split": "val",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.5,
+                "embedding": [100.0],
+            },
+        ]
+    )
+
+    predictions, _ = predict_ridge_probe(frame, alphas=(0.1,))
+
+    observed = predictions.filter(pl.col("observation_id") == "val-1").item(
+        0, "predicted_score"
+    )
+    assert observed > 50.0
+
+
+def test_predict_ridge_probe_rejects_program_with_too_few_train_rows() -> None:
+    frame = pl.DataFrame(
+        [
+            {
+                "observation_id": "train-1",
+                "sample_id": "s1",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.0,
+                "embedding": [0.0],
+            },
+            {
+                "observation_id": "val-1",
+                "sample_id": "s2",
+                "cohort_id": "cohort-a",
+                "split": "val",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.5,
+                "embedding": [0.5],
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="fewer than 2 train rows"):
+        predict_ridge_probe(frame)
+
+
+def test_predict_ridge_probe_rejects_program_without_val_rows() -> None:
+    frame = pl.DataFrame(
+        [
+            {
+                "observation_id": "train-1",
+                "sample_id": "s1",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.0,
+                "embedding": [0.0],
+            },
+            {
+                "observation_id": "train-2",
+                "sample_id": "s2",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 1.0,
+                "embedding": [1.0],
+            },
+        ]
+    )
+
+    with pytest.raises(ValueError, match="no val rows"):
+        predict_ridge_probe(frame)
+
+
+def test_predict_ridge_probe_breaks_alpha_ties_toward_smaller_value() -> None:
+    frame = pl.DataFrame(
+        [
+            {
+                "observation_id": "train-1",
+                "sample_id": "s1",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.5,
+                "embedding": [0.0],
+            },
+            {
+                "observation_id": "train-2",
+                "sample_id": "s2",
+                "cohort_id": "cohort-a",
+                "split": "train",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.5,
+                "embedding": [1.0],
+            },
+            {
+                "observation_id": "val-1",
+                "sample_id": "s3",
+                "cohort_id": "cohort-a",
+                "split": "val",
+                "program_name": "PROGRAM_A",
+                "raw_rank_evidence": 0.5,
+                "embedding": [0.2],
+            },
+        ]
+    )
+
+    _, selected_alpha_by_program = predict_ridge_probe(frame)
+
+    assert selected_alpha_by_program == {"PROGRAM_A": 0.1}

--- a/tests/baselines/test_run_baselines_cli.py
+++ b/tests/baselines/test_run_baselines_cli.py
@@ -55,7 +55,7 @@ def _write_inputs(score_path: Path, manifest_path: Path) -> None:
                     sample_id="s1",
                     program_name="HALLMARK_HYPOXIA",
                     status=ScoreStatus.OK,
-                    raw_rank_evidence=0.2,
+                    raw_rank_evidence=0.0,
                     signature_size_declared=10,
                     signature_size_matched=10,
                     signature_coverage=1.0,
@@ -66,7 +66,7 @@ def _write_inputs(score_path: Path, manifest_path: Path) -> None:
                     sample_id="s2",
                     program_name="HALLMARK_HYPOXIA",
                     status=ScoreStatus.OK,
-                    raw_rank_evidence=0.6,
+                    raw_rank_evidence=1.0,
                     signature_size_declared=10,
                     signature_size_matched=10,
                     signature_coverage=1.0,
@@ -77,7 +77,18 @@ def _write_inputs(score_path: Path, manifest_path: Path) -> None:
                     sample_id="s3",
                     program_name="HALLMARK_HYPOXIA",
                     status=ScoreStatus.OK,
-                    raw_rank_evidence=0.0,
+                    raw_rank_evidence=0.2,
+                    signature_size_declared=10,
+                    signature_size_matched=10,
+                    signature_coverage=1.0,
+                    dropped_by_missingness_rule=False,
+                ),
+                ScorePacket(
+                    observation_id="obs-4",
+                    sample_id="s4",
+                    program_name="HALLMARK_HYPOXIA",
+                    status=ScoreStatus.OK,
+                    raw_rank_evidence=0.5,
                     signature_size_declared=10,
                     signature_size_matched=10,
                     signature_coverage=1.0,
@@ -91,7 +102,8 @@ def _write_inputs(score_path: Path, manifest_path: Path) -> None:
         [
             {"sample_id": "s1", "cohort_id": "cohort-a", "split": "train"},
             {"sample_id": "s2", "cohort_id": "cohort-a", "split": "train"},
-            {"sample_id": "s3", "cohort_id": "external-b", "split": "test_external"},
+            {"sample_id": "s3", "cohort_id": "cohort-a", "split": "val"},
+            {"sample_id": "s4", "cohort_id": "external-b", "split": "test_external"},
         ]
     ).write_parquet(manifest_path)
 
@@ -104,22 +116,27 @@ def _write_embedding_inputs(embedding_path: Path) -> None:
             encoder_version="1.0.0",
             source_image_artifact_path="images.parquet",
             source_image_artifact_hash="d" * 64,
-            n_rows=3,
+            n_rows=4,
             rows=(
                 EmbeddingArtifactRow(
                     observation_id="obs-1",
                     sample_id="s1",
-                    embedding=(0.1, 0.2),
+                    embedding=(1.0,),
                 ),
                 EmbeddingArtifactRow(
                     observation_id="obs-2",
                     sample_id="s2",
-                    embedding=(0.2, 0.3),
+                    embedding=(2.0,),
                 ),
                 EmbeddingArtifactRow(
                     observation_id="obs-3",
                     sample_id="s3",
-                    embedding=(0.3, 0.4),
+                    embedding=(1.2,),
+                ),
+                EmbeddingArtifactRow(
+                    observation_id="obs-4",
+                    sample_id="s4",
+                    embedding=(1.5,),
                 ),
             ),
         ),
@@ -158,7 +175,7 @@ def test_run_baselines_cli_writes_prediction_artifact(tmp_path: Path) -> None:
     assert result.exit_code == 0
     assert output_path.exists()
     artifact = read_baseline_prediction_artifact(output_path)
-    assert artifact.n_rows == 6
+    assert artifact.n_rows == 8
 
 
 def test_run_baselines_cli_writes_mean_and_knn_predictions_with_embeddings(
@@ -198,11 +215,15 @@ def test_run_baselines_cli_writes_mean_and_knn_predictions_with_embeddings(
     assert result.exit_code == 0
     assert output_path.exists()
     artifact = read_baseline_prediction_artifact(output_path)
-    assert artifact.n_rows == 9
+    assert artifact.n_rows == 16
     assert {row.baseline_name for row in artifact.rows} == {
         BaselineName.GLOBAL_TRAIN_MEAN,
         BaselineName.MEAN_BY_TRAIN_COHORT,
         BaselineName.KNN_ON_EMBEDDINGS,
+        BaselineName.RIDGE_PROBE,
+    }
+    assert artifact.ridge_probe_selected_alpha_by_program == {
+        "HALLMARK_HYPOXIA": 0.1
     }
 
 

--- a/tests/baselines/test_runner.py
+++ b/tests/baselines/test_runner.py
@@ -31,7 +31,7 @@ def _score_artifact(
             sample_id="s1",
             program_name="HALLMARK_HYPOXIA",
             status=ScoreStatus.OK,
-            raw_rank_evidence=0.2,
+            raw_rank_evidence=0.0,
             signature_size_declared=10,
             signature_size_matched=10,
             signature_coverage=1.0,
@@ -42,7 +42,7 @@ def _score_artifact(
             sample_id="s2",
             program_name="HALLMARK_HYPOXIA",
             status=ScoreStatus.OK,
-            raw_rank_evidence=0.6,
+            raw_rank_evidence=1.0,
             signature_size_declared=10,
             signature_size_matched=10,
             signature_coverage=1.0,
@@ -53,7 +53,7 @@ def _score_artifact(
             sample_id=sample_id_obs3,
             program_name="HALLMARK_HYPOXIA",
             status=ScoreStatus.OK,
-            raw_rank_evidence=0.1,
+            raw_rank_evidence=0.2,
             signature_size_declared=10,
             signature_size_matched=10,
             signature_coverage=1.0,
@@ -61,10 +61,10 @@ def _score_artifact(
         ),
         ScorePacket(
             observation_id="obs-4",
-            sample_id="s4" if include_missing_manifest_row else "s3",
+            sample_id="s5" if include_missing_manifest_row else "s4",
             program_name="HALLMARK_HYPOXIA",
             status=ScoreStatus.OK,
-            raw_rank_evidence=0.0,
+            raw_rank_evidence=0.5,
             signature_size_declared=10,
             signature_size_matched=10,
             signature_coverage=1.0,
@@ -89,28 +89,31 @@ def _score_artifact(
     )
 
 
-def _write_manifest(path: Path, *, duplicate_sample_id: bool = False) -> None:
+def _write_manifest(
+    path: Path,
+    *,
+    duplicate_sample_id: bool = False,
+    split_by_sample: dict[str, str] | None = None,
+) -> None:
+    if split_by_sample is None:
+        split_by_sample = {
+            "s1": "train",
+            "s2": "train",
+            "s3": "val",
+            "s4": "test_external",
+        }
     rows = [
         {
-            "sample_id": "s1",
-            "cohort_id": "cohort-a",
-            "split": "train",
-        },
-        {
-            "sample_id": "s2",
-            "cohort_id": "cohort-a",
-            "split": "train",
-        },
-        {
-            "sample_id": "s3",
-            "cohort_id": "external-b",
-            "split": "test_external",
-        },
+            "sample_id": sample_id,
+            "cohort_id": "external-b" if split == "test_external" else "cohort-a",
+            "split": split,
+        }
+        for sample_id, split in split_by_sample.items()
     ]
     if duplicate_sample_id:
         rows.append(
             {
-                "sample_id": "s3",
+                "sample_id": "s4",
                 "cohort_id": "external-b",
                 "split": "test_external",
             }
@@ -129,32 +132,32 @@ def _write_embedding_artifact(
         EmbeddingArtifactRow.model_construct(
             observation_id="obs-1",
             sample_id="s1",
-            embedding=(0.1, 0.2),
+            embedding=(1.0,),
         ),
         EmbeddingArtifactRow.model_construct(
             observation_id="obs-2",
             sample_id="s2",
-            embedding=(0.3, 0.4, 0.5) if inconsistent_dimensions else (0.3, 0.4),
+            embedding=(2.0, 3.0) if inconsistent_dimensions else (2.0,),
         ),
         EmbeddingArtifactRow.model_construct(
             observation_id="obs-3",
             sample_id="s3",
-            embedding=(0.5, 0.6),
+            embedding=(1.2,),
         ),
     ]
     if include_obs4:
         rows.append(
             EmbeddingArtifactRow.model_construct(
                 observation_id="obs-4",
-                sample_id="s3",
-                embedding=(0.7, 0.8),
+                sample_id="s4",
+                embedding=(1.5,),
             )
         )
     if duplicate_observation_id:
         rows[-1] = EmbeddingArtifactRow.model_construct(
             observation_id="obs-3",
             sample_id="s3",
-            embedding=(0.7, 0.8),
+            embedding=(1.5,),
         )
     artifact = EmbeddingArtifact.model_construct(
         alignment_contract_id="alignment-v1",
@@ -218,17 +221,28 @@ def test_run_mean_baselines_writes_mean_and_knn_predictions_with_embeddings(
     )
 
     assert output_path.exists()
-    assert artifact.n_rows == 12
+    assert artifact.n_rows == 16
     assert {row.baseline_name for row in artifact.rows} == {
         BaselineName.GLOBAL_TRAIN_MEAN,
         BaselineName.MEAN_BY_TRAIN_COHORT,
         BaselineName.KNN_ON_EMBEDDINGS,
+        BaselineName.RIDGE_PROBE,
+    }
+    assert artifact.ridge_probe_selected_alpha_by_program == {
+        "HALLMARK_HYPOXIA": 0.1
     }
     assert len(
         [
             row
             for row in artifact.rows
             if row.baseline_name is BaselineName.KNN_ON_EMBEDDINGS
+        ]
+    ) == 4
+    assert len(
+        [
+            row
+            for row in artifact.rows
+            if row.baseline_name is BaselineName.RIDGE_PROBE
         ]
     ) == 4
 
@@ -325,10 +339,75 @@ def test_run_mean_baselines_without_embeddings_preserves_mean_only_behavior(
     )
 
     assert artifact.n_rows == 8
+    assert artifact.ridge_probe_selected_alpha_by_program is None
     assert {row.baseline_name for row in artifact.rows} == {
         BaselineName.GLOBAL_TRAIN_MEAN,
         BaselineName.MEAN_BY_TRAIN_COHORT,
     }
+
+
+def test_run_mean_baselines_with_embeddings_rejects_program_without_val_rows(
+    tmp_path: Path,
+) -> None:
+    score_path = tmp_path / "scores.parquet"
+    manifest_path = tmp_path / "manifest.parquet"
+    embedding_path = tmp_path / "embeddings.parquet"
+    output_path = tmp_path / "baseline_predictions.parquet"
+    write_score_artifact(_score_artifact(), score_path)
+    _write_manifest(
+        manifest_path,
+        split_by_sample={
+            "s1": "train",
+            "s2": "train",
+            "s3": "test_external",
+            "s4": "test_external",
+        },
+    )
+    _write_embedding_artifact(embedding_path)
+
+    with pytest.raises(ValueError, match="no val rows"):
+        run_mean_baselines(
+            score_artifact_path=score_path,
+            manifest_path=manifest_path,
+            output_path=output_path,
+            run_id="baseline-run-1",
+            baseline_contract_id="mean_baselines_v0",
+            split_contract_id="breast_visium_split_v1",
+            manifest_id="manifest-v1",
+            embedding_artifact_path=embedding_path,
+        )
+
+
+def test_run_mean_baselines_with_embeddings_rejects_program_with_too_few_train_rows(
+    tmp_path: Path,
+) -> None:
+    score_path = tmp_path / "scores.parquet"
+    manifest_path = tmp_path / "manifest.parquet"
+    embedding_path = tmp_path / "embeddings.parquet"
+    output_path = tmp_path / "baseline_predictions.parquet"
+    write_score_artifact(_score_artifact(), score_path)
+    _write_manifest(
+        manifest_path,
+        split_by_sample={
+            "s1": "train",
+            "s2": "val",
+            "s3": "test_external",
+            "s4": "test_external",
+        },
+    )
+    _write_embedding_artifact(embedding_path)
+
+    with pytest.raises(ValueError, match="fewer than 2 train rows"):
+        run_mean_baselines(
+            score_artifact_path=score_path,
+            manifest_path=manifest_path,
+            output_path=output_path,
+            run_id="baseline-run-1",
+            baseline_contract_id="mean_baselines_v0",
+            split_contract_id="breast_visium_split_v1",
+            manifest_id="manifest-v1",
+            embedding_artifact_path=embedding_path,
+        )
 
 
 def test_run_mean_baselines_rejects_missing_sample_id_on_ok_score_row(


### PR DESCRIPTION
## Summary
- add the frozen ridge_probe deployable baseline on top of the existing baseline runner
- record artifact-level ridge_probe_selected_alpha_by_program metadata
- update CLI/docs for the full embedding-aware baseline stack

Closes #15

## Verification
- uv run pytest tests/baselines/test_baseline_artifacts.py tests/baselines/test_ridge.py tests/baselines/test_runner.py tests/baselines/test_run_baselines_cli.py -q
- uv run ruff check .
- uv run mypy src tests scripts/build_manifest.py scripts/run_baselines.py
- uv run pytest -q