### PR TITLE
fix: harden embedding provenance and r bridge

### DIFF
--- a/src/spatial_ci/embeddings/artifacts.py
+++ b/src/spatial_ci/embeddings/artifacts.py
@@ -33,6 +33,30 @@ class EmbeddingArtifact(BaseModel):
 
     @model_validator(mode="after")
     def _validate_rows(self) -> "EmbeddingArtifact":
+        if self.source_image_artifact_path == "":
+            raise ValueError("source_image_artifact_path must be non-empty when set")
+
+        if self.source_image_artifact_hash == "":
+            raise ValueError("source_image_artifact_hash must be non-empty when set")
+
+        if (
+            self.source_image_artifact_path is None
+            and self.source_image_artifact_hash is not None
+        ):
+            raise ValueError(
+                "source_image_artifact_path is required when "
+                "source_image_artifact_hash is set"
+            )
+
+        if (
+            self.source_image_artifact_path is not None
+            and self.source_image_artifact_hash is None
+        ):
+            raise ValueError(
+                "source_image_artifact_hash is required when "
+                "source_image_artifact_path is set"
+            )
+
         if self.n_rows != len(self.rows):
             raise ValueError("n_rows must match len(rows)")
 

--- a/src/spatial_ci/scoring/r_bridge.py
+++ b/src/spatial_ci/scoring/r_bridge.py
@@ -1,6 +1,8 @@
 """File-based bridge between Python policy code and the R scorer."""
 
 import json
+import os
+import signal
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -29,6 +31,9 @@ class InvalidScorerOutputError(RuntimeError):
     """Raised when the R scorer output artifact is malformed."""
 
 
+R_SCRIPT_TIMEOUT_SECONDS = 300
+
+
 def build_bridge_paths(workdir: Path) -> BridgePaths:
     """Build the deterministic bridge file layout inside a workdir."""
 
@@ -42,27 +47,77 @@ def build_bridge_paths(workdir: Path) -> BridgePaths:
     )
 
 
-def run_r_script(
-    paths: BridgePaths, *, repo_root: Path
-) -> subprocess.CompletedProcess[str]:
-    """Invoke the canonical R scorer with the explicit bridge inputs."""
+def _reap_orphaned_r_scorer_processes() -> None:
+    """Terminate orphaned score_targets.R processes from interrupted runs."""
 
-    completed = subprocess.run(
-        [
-            "Rscript",
-            "scripts/score_targets.R",
-            str(paths.expression_input),
-            str(paths.signature_input),
-            str(paths.scoring_request),
-            str(paths.detected_membership),
-            str(paths.score_output),
-            str(paths.runtime_metadata),
-        ],
-        cwd=repo_root,
+    listing = subprocess.run(
+        ["ps", "-Ao", "pid,ppid,command"],
         capture_output=True,
         text=True,
         check=False,
     )
+    if listing.returncode != 0:
+        return
+
+    orphan_pids: list[int] = []
+    for line in listing.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        parts = stripped.split(maxsplit=2)
+        if len(parts) < 3:
+            continue
+        pid_text, ppid_text, command = parts
+        if ppid_text != "1":
+            continue
+        if "scripts/score_targets.R" not in command:
+            continue
+        try:
+            orphan_pids.append(int(pid_text))
+        except ValueError:
+            continue
+
+    for pid in orphan_pids:
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except (PermissionError, ProcessLookupError):
+            continue
+
+
+def run_r_script(
+    paths: BridgePaths,
+    *,
+    repo_root: Path,
+    timeout_seconds: int = R_SCRIPT_TIMEOUT_SECONDS,
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the canonical R scorer with the explicit bridge inputs."""
+
+    if timeout_seconds < 1:
+        raise ValueError("timeout_seconds must be at least 1")
+
+    _reap_orphaned_r_scorer_processes()
+    try:
+        completed = subprocess.run(
+            [
+                "Rscript",
+                "scripts/score_targets.R",
+                str(paths.expression_input),
+                str(paths.signature_input),
+                str(paths.scoring_request),
+                str(paths.detected_membership),
+                str(paths.score_output),
+                str(paths.runtime_metadata),
+            ],
+            cwd=repo_root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise RSubprocessError(
+            f"R scorer timed out after {timeout_seconds}s."
+        ) from exc
 
     if completed.returncode != 0:
         raise RSubprocessError(completed.stderr.strip() or "R scorer failed.")

--- a/tests/embeddings/test_artifacts.py
+++ b/tests/embeddings/test_artifacts.py
@@ -179,6 +179,41 @@ def test_embedding_artifact_requires_row_sample_id_and_metadata_fields() -> None
         )
 
 
+def test_embedding_artifact_requires_complete_non_empty_source_provenance() -> None:
+    with pytest.raises(ValidationError, match="source_image_artifact_path"):
+        EmbeddingArtifact(
+            alignment_contract_id="alignment-v1",
+            encoder_name="clip-vit-b32",
+            encoder_version="1.0.0",
+            source_image_artifact_path="",
+            source_image_artifact_hash="a" * 64,
+            n_rows=0,
+            rows=(),
+        )
+
+    with pytest.raises(ValidationError, match="source_image_artifact_hash"):
+        EmbeddingArtifact(
+            alignment_contract_id="alignment-v1",
+            encoder_name="clip-vit-b32",
+            encoder_version="1.0.0",
+            source_image_artifact_path="images/source.tiff",
+            source_image_artifact_hash=None,
+            n_rows=0,
+            rows=(),
+        )
+
+    with pytest.raises(ValidationError, match="source_image_artifact_path"):
+        EmbeddingArtifact(
+            alignment_contract_id="alignment-v1",
+            encoder_name="clip-vit-b32",
+            encoder_version="1.0.0",
+            source_image_artifact_path=None,
+            source_image_artifact_hash="a" * 64,
+            n_rows=0,
+            rows=(),
+        )
+
+
 def test_embedding_artifact_rejects_unexpected_row_and_metadata_keys() -> None:
     with pytest.raises(ValidationError, match="extra"):
         EmbeddingArtifactRow.model_validate(

--- a/tests/scoring/test_r_bridge.py
+++ b/tests/scoring/test_r_bridge.py
@@ -1,4 +1,5 @@
 import json
+import signal
 import subprocess
 from pathlib import Path
 
@@ -33,6 +34,11 @@ def test_bridge_paths_are_explicit_and_stable(tmp_path: Path) -> None:
 def test_nonzero_r_exit_maps_to_subprocess_error(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
+    monkeypatch.setattr(
+        "spatial_ci.scoring.r_bridge._reap_orphaned_r_scorer_processes",
+        lambda: None,
+    )
+
     def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
             args=["Rscript"],
@@ -45,6 +51,92 @@ def test_nonzero_r_exit_maps_to_subprocess_error(
 
     with pytest.raises(RSubprocessError, match="scorer blew up"):
         run_r_script(build_bridge_paths(tmp_path), repo_root=tmp_path)
+
+
+def test_timeout_maps_to_subprocess_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(
+        "spatial_ci.scoring.r_bridge._reap_orphaned_r_scorer_processes",
+        lambda: None,
+    )
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise subprocess.TimeoutExpired(cmd=["Rscript"], timeout=1)
+
+    monkeypatch.setattr("spatial_ci.scoring.r_bridge.subprocess.run", fake_run)
+
+    with pytest.raises(RSubprocessError, match="timed out"):
+        run_r_script(
+            build_bridge_paths(tmp_path),
+            repo_root=tmp_path,
+            timeout_seconds=1,
+        )
+
+
+def test_timeout_must_be_positive(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="timeout_seconds"):
+        run_r_script(
+            build_bridge_paths(tmp_path),
+            repo_root=tmp_path,
+            timeout_seconds=0,
+        )
+
+
+def test_reap_orphaned_r_scorer_processes_kills_only_matching_orphans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sample_ps = "\n".join(
+        [
+            "101 1 /opt/homebrew/lib/R --file=scripts/score_targets.R --args foo",
+            "102 2 /opt/homebrew/lib/R --file=scripts/score_targets.R --args bar",
+            "103 1 /opt/homebrew/lib/R --file=scripts/bootstrap_renv.R",
+            "104 1 /opt/homebrew/lib/R --file=scripts/other.R",
+        ]
+    )
+    calls: list[tuple[int, int]] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["ps"],
+            returncode=0,
+            stdout=sample_ps,
+            stderr="",
+        )
+
+    def fake_kill(pid: int, sig: int) -> None:
+        calls.append((pid, sig))
+
+    monkeypatch.setattr("spatial_ci.scoring.r_bridge.subprocess.run", fake_run)
+    monkeypatch.setattr("spatial_ci.scoring.r_bridge.os.kill", fake_kill)
+
+    from spatial_ci.scoring.r_bridge import _reap_orphaned_r_scorer_processes
+
+    _reap_orphaned_r_scorer_processes()
+
+    assert calls == [(101, signal.SIGTERM)]
+
+
+def test_reap_ignores_unreadable_process_listing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(
+            args=["ps"],
+            returncode=1,
+            stdout="",
+            stderr="denied",
+        )
+
+    def fail_kill(pid: int, sig: int) -> None:
+        raise AssertionError("kill should not be called when ps fails")
+
+    monkeypatch.setattr("spatial_ci.scoring.r_bridge.subprocess.run", fake_run)
+    monkeypatch.setattr("spatial_ci.scoring.r_bridge.os.kill", fail_kill)
+
+    from spatial_ci.scoring.r_bridge import _reap_orphaned_r_scorer_processes
+
+    _reap_orphaned_r_scorer_processes()
 
 
 def test_missing_required_output_column_maps_to_invalid_output(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- require embedding image provenance to be either fully absent or fully populated and non-empty
- add regression coverage for provenance validation and canonical artifact behavior
- add an R bridge timeout plus orphaned `score_targets.R` reaping guards, with unit coverage

## Test Plan
- [x] `PYTHONDONTWRITEBYTECODE=1 uv run pytest -q tests/embeddings/test_artifacts.py tests/scoring/test_r_bridge.py -k 'not missing_bridge_input_maps_to_clear_r_error'`
- [x] `uv run ruff check src/spatial_ci/embeddings/artifacts.py src/spatial_ci/scoring/r_bridge.py tests/embeddings/test_artifacts.py tests/scoring/test_r_bridge.py`
- [x] `uv run mypy src/spatial_ci/embeddings/artifacts.py src/spatial_ci/scoring/r_bridge.py tests/embeddings/test_artifacts.py tests/scoring/test_r_bridge.py`
- [ ] `uv run pytest -q tests/scoring/test_r_bridge.py` still depends on a local R `arrow` install for the existing integration case